### PR TITLE
fix file dialogs on system that provide native implementations

### DIFF
--- a/papi/gui/default/custom.py
+++ b/papi/gui/default/custom.py
@@ -116,6 +116,7 @@ class ColorLineEdit(QPushButton):
 class PaPIConfigSaveDialog(QtWidgets.QFileDialog):
     def __init__(self, parent, gui_api):
         super(PaPIConfigSaveDialog, self).__init__(parent)
+        self.setOption(QtWidgets.QFileDialog.DontUseNativeDialog)
 
         inital_hidden = True
 
@@ -125,7 +126,7 @@ class PaPIConfigSaveDialog(QtWidgets.QFileDialog):
 
         self.setFileMode(QFileDialog.AnyFile)
         self.setNameFilters( [ self.tr("PaPI-Cfg (*.xml)"), self.tr("PaPI-Cfg (*.json)") ])
-        self.setDirectory(pc.CONFIG_DEFAULT_DIRECTORY)
+        self.setDirectory(os.path.abspath(pc.CONFIG_DEFAULT_DIRECTORY))
         self.setWindowTitle("Save Configuration")
         self.setAcceptMode(QFileDialog.AcceptSave)
 

--- a/papi/gui/default/main.py
+++ b/papi/gui/default/main.py
@@ -568,7 +568,7 @@ class GUI(QMainWindow, Ui_DefaultMain):
         dialog = QFileDialog(self)
         dialog.setFileMode(QFileDialog.ExistingFile)
         dialog.setNameFilter( self.tr("PaPI-Cfg (*.xml)"))
-        dialog.setDirectory(pc.CONFIG_DEFAULT_DIRECTORY)
+        dialog.setDirectory(os.path.abspath(pc.CONFIG_DEFAULT_DIRECTORY))
         dialog.setWindowTitle("Load Configuration")
 
         if dialog.exec_():


### PR DESCRIPTION
for the save dialog, set the DontUseNativeDialog flag since this
is required for extending the file dialog. for the load dialog, use
an absolute default path.